### PR TITLE
Handle tokens with mint key

### DIFF
--- a/bot/buyer.py
+++ b/bot/buyer.py
@@ -3,21 +3,28 @@
 import os
 from bot.trader import trade_local
 
+
 def buy_token(token):
     private_key = os.getenv("PRIVATE_KEY")
     if not private_key:
         print("❌ PRIVATE_KEY is missing in .env")
         return False
 
+    token_mint = token.get("address") or token.get("mint")
+    if not token_mint:
+        print("❌ No token mint address provided")
+        return False
+
     try:
         response = trade_local(
             private_key=private_key,
-            token_mint=token["address"],
+            token_mint=token_mint,
             amount_sol=0.01,  # Reduced to 0.00001 SOL for extremely low liquidity tokens
-            side="buy"
+            side="buy",
         )
         print(f"✅ Buy executed: {response}")
         return True
     except Exception as e:
-        print(f"❌ Failed to buy {token['symbol']}: {e}")
+        print(f"❌ Failed to buy {token.get('symbol', token_mint)}: {e}")
         return False
+

--- a/bot/seller.py
+++ b/bot/seller.py
@@ -24,7 +24,11 @@ def sell_token(token):
 
         keypair = Keypair.from_bytes(base58.b58decode(private_key))
         wallet = keypair.pubkey()
-        token_address = Pubkey.from_string(token["address"])
+        token_address = token.get("address") or token.get("mint")
+        if not token_address:
+            print("❌ No token address provided.")
+            return False
+        token_address = Pubkey.from_string(token_address)
 
         txid = trade_local(
             buyer=wallet,


### PR DESCRIPTION
## Summary
- allow buyer to use `mint` or `address` field for token identifiers and validate presence
- allow seller to accept `mint` or `address` before constructing trade

## Testing
- `pytest -q` *(fails: IndentationError in test_websocket_subscription.py)*
- `pytest tests/test_rug_filters.py tests/test_trade_logic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689b2fb2bad883319e3d310d1c463822