### PR TITLE
Avoid sending invalid Pump.fun WebSocket subscribe message

### DIFF
--- a/bot/scanner.py
+++ b/bot/scanner.py
@@ -68,11 +68,9 @@ def run_scanner(on_token_callback):
 
     def on_open(ws):
         log_print("✅ WebSocket connected and listening for new tokens...")
-        # Subscribe to new token events if required by the server.
-        try:
-            ws.send(json.dumps({"type": "subscribe", "channel": "new_token"}))
-        except Exception as e:
-            log_print(f"⚠️ Failed to send subscribe message: {e}")
+        # The public feed immediately streams new tokens; no subscription needed.
+        # Some endpoints return errors if a subscribe message is sent, so we
+        # simply start listening without sending anything.
 
     def on_error(ws, error):
         log_print(f"❌ WebSocket Error: {error}")

--- a/test_websocket_subscription.py
+++ b/test_websocket_subscription.py
@@ -9,7 +9,6 @@ import websocket
 
 
 WEBSOCKET_URL = "wss://pumpportal.fun/api/ws"
-SUBSCRIBE_MSG = {"type": "subscribe", "channel": "new_token"}
 
 
 def on_message(ws, message):
@@ -35,9 +34,8 @@ def on_close(ws, code, msg):
 
 
 def on_open(ws):
+    # The feed immediately starts streaming data once connected.
     print("📡 Connected to PumpPortal WebSocket")
-    ws.send(json.dumps(SUBSCRIBE_MSG))
-    print("✅ Subscription message sent")
 
 
 def test_websocket_subscription():

--- a/utils/live_token_scanner.py
+++ b/utils/live_token_scanner.py
@@ -19,11 +19,9 @@ async def handle_new_token(data):
 
 async def scanner():
     async with websockets.connect(PUMPFUN_WS) as ws:
-        try:
-            # Subscribe to the new token feed.
-            await ws.send(json.dumps({"type": "subscribe", "channel": "new_token"}))
-        except Exception as e:
-            log_print(f"[Scanner Error] Failed to subscribe: {e}")
+        # The feed pushes events without any subscription message.
+        # Sending a subscribe request results in an error response, so we just
+        # listen immediately after connecting.
         while True:
             try:
                 msg = await ws.recv()


### PR DESCRIPTION
## Summary
- Stop sending subscribe message when connecting to Pump.fun WebSocket feed since it returns an error.
- Update async scanner and test to listen without subscription.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b422d15808331a32c9d70b515ab40